### PR TITLE
Fixes forever wait of agent & new aquariumSnapshot step for pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ in the cluster.
 Aquarium Fish cluster will decide which node can handle the resource request, run the resource and
 connect to the created agent node to serve the build needs.
 
+### Pipeline steps
+
+You can use the next steps in the pipeline:
+
+* `aquariumSnapshot()` (`full: false`)
+   Trigger the current Aquarium Application to snapshot the current state. What actually will be
+   captured really depends on the Label driver, but in general the rules are:
+     * `full: false` - partial snapshot, just the attached disks except for the root disk.
+     * `full: true` - full snapshot including root disk and, if possible, memory of the running env.
+
 ## Implementation
 
 The implementation is still PoC and not perfect in any way. For now it's mostly working.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.adobe.ci.aquarium</groupId>
     <artifactId>aquarium-net-jenkins</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Aquarium Net Jenkins Plugin</name>
     <description>Dynamically allocates required resources from Aquarium Fish cluster nodes</description>
@@ -73,6 +73,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
         </dependency>
 
         <!-- OpenAPI deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.adobe.ci.aquarium</groupId>
     <artifactId>aquarium-net-jenkins</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Aquarium Net Jenkins Plugin</name>
     <description>Dynamically allocates required resources from Aquarium Fish cluster nodes</description>

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -149,6 +149,11 @@ public class AquariumClient {
         return new ApplicationApi(api_client_pool.get(0)).applicationStateGet(app_id);
     }
 
+    public void applicationSnapshot(Long app_id, Boolean full) throws Exception {
+        startConnection();
+        new ApplicationApi(api_client_pool.get(0)).applicationSnapshotGet(app_id, full);
+    }
+
     public void applicationDeallocate(Long app_id) throws Exception {
         startConnection();
         new ApplicationApi(api_client_pool.get(0)).applicationDeallocateGet(app_id);

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumSlave.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumSlave.java
@@ -52,7 +52,7 @@ public class AquariumSlave extends AbstractCloudSlave {
             .getInteger(AquariumSlave.class.getName() + ".disconnectionTimeout", 5);
 
     private static final long serialVersionUID = -8642936855413034232L;
-    private static final String DEFAULT_AGENT_PREFIX = "jenkins-agent";
+    private static final String DEFAULT_AGENT_PREFIX = "fish";
 
     private final String cloudName;
     private transient Set<Queue.Executable> executables = new HashSet<>();
@@ -70,6 +70,10 @@ public class AquariumSlave extends AbstractCloudSlave {
 
     public String getCloudName() {
         return cloudName;
+    }
+
+    public Long getApplicationId() {
+        return this.application_id;
     }
 
     @Override
@@ -116,7 +120,7 @@ public class AquariumSlave extends AbstractCloudSlave {
     }
 
     static String getSlaveName() {
-        String randString = RandomStringUtils.random(5, "bcdfghjklmnpqrstvwxz0123456789");
+        String randString = RandomStringUtils.random(8, "bcdfghjklmnpqrstvwxz0123456789");
         return String.format("%s-%s", DEFAULT_AGENT_PREFIX, randString);
     }
 

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.ci.aquarium.net.pipeline;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AquariumSnapshotStep extends Step implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private boolean full = false;
+
+    @DataBoundSetter
+    public void setFull(boolean full) {
+        this.full = full;
+    }
+
+    public boolean isFull() {
+        return this.full;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AquariumSnapshotStepExecution(this, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "aquariumSnapshot";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Make snapshot of the current node";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Node.class)));
+        }
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep.java
@@ -34,6 +34,8 @@ public class AquariumSnapshotStep extends Step implements Serializable {
 
     private boolean full = false;
 
+    @DataBoundConstructor public AquariumSnapshotStep() {}
+
     @DataBoundSetter
     public void setFull(boolean full) {
         this.full = full;

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStepExecution.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStepExecution.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.ci.aquarium.net.pipeline;
+
+import com.adobe.ci.aquarium.net.AquariumCloud;
+import hudson.model.TaskListener;
+import hudson.util.LogTaskListener;
+import hudson.model.Node;
+import hudson.AbortException;
+import com.adobe.ci.aquarium.net.AquariumSlave;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+
+import java.io.PrintStream;
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+public class AquariumSnapshotStepExecution extends SynchronousNonBlockingStepExecution<String> {
+    private static final long serialVersionUID = 1L;
+    private static final transient Logger LOGGER = Logger.getLogger(AquariumSnapshotStepExecution.class.getName());
+
+    private final AquariumSnapshotStep step;
+
+    AquariumSnapshotStepExecution(AquariumSnapshotStep step, StepContext context) {
+        super(context);
+        this.step = step;
+    }
+
+    private PrintStream logger() {
+        TaskListener l = null;
+        StepContext context = getContext();
+        try {
+            l = context.get(TaskListener.class);
+        } catch (Exception x) {
+            LOGGER.log(Level.WARNING, "Failed to find TaskListener in context");
+        } finally {
+            if (l == null) {
+                l = new LogTaskListener(LOGGER, Level.FINE);
+            }
+        }
+        return l.getLogger();
+    }
+
+    @Override
+    protected String run() throws Exception {
+        boolean full = step.isFull();
+
+        try {
+            LOGGER.log(Level.FINE, "Starting containerLog step.");
+
+            Node node = getContext().get(Node.class);
+            if( !(node instanceof AquariumSlave) ) {
+                throw new AbortException(
+                        String.format("Node is not an Aquarium node: %s", node != null ? node.getNodeName() : null));
+            }
+
+            Long app_id = ((AquariumSlave)node).getApplicationId();
+            AquariumCloud cloud = ((AquariumSlave)node).getAquariumCloud();
+
+            cloud.getClient().applicationSnapshot(app_id, full);
+
+            return "";
+        } catch (InterruptedException e) {
+            String msg = "Interrupted while requesting snapshot of the Application";
+            logger().println(msg);
+            LOGGER.log(Level.FINE, msg);
+            return "";
+        } catch (Exception e) {
+            String msg = "Failed to request snapshot of the Application";
+            logger().println(msg);
+            LOGGER.log(Level.WARNING, msg, e);
+            return "";
+        }
+    }
+
+    @Override
+    public void stop(Throwable cause) throws Exception {
+        LOGGER.log(Level.FINE, "Stopping Aquarium snapshot step.");
+        super.stop(cause);
+    }
+}

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep/config.jelly
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:block>
+        <p>
+            Triggers the snapshot operation of the current Aquarium Fish Application Resource.
+            Please make sure the disks are unmounted or synced if the driver supports just disk snapshots.
+        </p>
+    </f:block>
+    <f:entry field="full" title="Make full environment snapshot">
+        <f:checkbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep/help-full.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStep/help-full.html
@@ -1,0 +1,3 @@
+<div>
+    Makes full environment snapshot instead of a partial one. Full - means as much as possible (depends on provider capabilities), not full only snapshots the attached disks except for the image root disk.
+</div>


### PR DESCRIPTION
The change fixes an issue with forever wait of the agent even if it's not needed anymore and the new pipeline step `aquariumSnapshot` to trigger the snapshot process for the current node.

## Motivation and Context

It enables the pipelines to save their state for future (during failure handling for example).

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

