### PR TITLE
Updated plugin to support fish updates in #19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.adobe.ci.aquarium</groupId>
     <artifactId>aquarium-net-jenkins</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Aquarium Net Jenkins Plugin</name>
     <description>Dynamically allocates required resources from Aquarium Fish cluster nodes</description>

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -33,10 +33,7 @@ import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 public class AquariumClient {
     String node_url; // TODO: replace with nodes pool
@@ -139,24 +136,24 @@ public class AquariumClient {
 
         app.setMetadata(metadata);
         // Sorting the labels by version and using the max one
-        app.setLabelID(labels.stream().max(Comparator.comparing(l -> l.getVersion())).get().getID());
+        app.setLabelUID(labels.stream().max(Comparator.comparing(l -> l.getVersion())).get().getUID());
 
         return new ApplicationApi(api_client_pool.get(0)).applicationCreatePost(app);
     }
 
-    public ApplicationState applicationStateGet(Long app_id) throws Exception {
+    public ApplicationState applicationStateGet(UUID app_uid) throws Exception {
         startConnection();
-        return new ApplicationApi(api_client_pool.get(0)).applicationStateGet(app_id);
+        return new ApplicationApi(api_client_pool.get(0)).applicationStateGet(app_uid);
     }
 
-    public void applicationSnapshot(Long app_id, Boolean full) throws Exception {
+    public void applicationSnapshot(UUID app_uid, Boolean full) throws Exception {
         startConnection();
-        new ApplicationApi(api_client_pool.get(0)).applicationSnapshotGet(app_id, full);
+        new ApplicationApi(api_client_pool.get(0)).applicationSnapshotGet(app_uid, full);
     }
 
-    public void applicationDeallocate(Long app_id) throws Exception {
+    public void applicationDeallocate(UUID app_uid) throws Exception {
         startConnection();
-        new ApplicationApi(api_client_pool.get(0)).applicationDeallocateGet(app_id);
+        new ApplicationApi(api_client_pool.get(0)).applicationDeallocateGet(app_uid);
     }
 
     public User meGet() throws Exception {

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
@@ -74,7 +74,7 @@ public class AquariumLauncher extends JNLPLauncher {
                     cloud.getMetadata()
             );
 
-            node.setApplicationId(app.getID());
+            node.setApplicationUID(app.getUID());
 
             // Wait for fish node election process - it could take a while if there not enough resources in the pool
             SlaveComputer slaveComputer;
@@ -90,7 +90,7 @@ public class AquariumLauncher extends JNLPLauncher {
 
                 // Check that the resource hasn't failed already
                 try {
-                    state = client.applicationStateGet(app.getID());
+                    state = client.applicationStateGet(app.getUID());
                     if( state.getStatus() == ApplicationState.StatusEnum.ALLOCATED ) {
                         break;
                     } else if( state.getStatus() != ApplicationState.StatusEnum.ELECTED && state.getStatus() != ApplicationState.StatusEnum.NEW) {
@@ -118,7 +118,7 @@ public class AquariumLauncher extends JNLPLauncher {
 
                 // Check that the resource hasn't failed already
                 try {
-                    state = client.applicationStateGet(app.getID());
+                    state = client.applicationStateGet(app.getUID());
                     if( state.getStatus() != ApplicationState.StatusEnum.ALLOCATED ) {
                         LOG.log(Level.WARNING, "Agent did not connected:" + state.getDescription() + ", node:" + comp.getName());
                         break;

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStepExecution.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumSnapshotStepExecution.java
@@ -22,6 +22,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
 import java.io.PrintStream;
+import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -64,7 +65,7 @@ public class AquariumSnapshotStepExecution extends SynchronousNonBlockingStepExe
                         String.format("Node is not an Aquarium node: %s", node != null ? node.getNodeName() : null));
             }
 
-            Long app_id = ((AquariumSlave)node).getApplicationId();
+            UUID app_id = ((AquariumSlave)node).getApplicationUID();
             AquariumCloud cloud = ((AquariumSlave)node).getAquariumCloud();
 
             cloud.getClient().applicationSnapshot(app_id, full);


### PR DESCRIPTION
The plugin migrated to using UIDs in Aquarium Fish in was introduced in adobe/aquarium-fish#19 and allows to work with this version of Fish . Also the deallocation of the resource was a bit improved.

WARNING: The older versions of Fish based on dqlite will not work with the updated plugin.

## Related Issue

Related: adobe/aquarium-fish#19

## Motivation and Context

In order to keep the plugin up to date

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

