### PR TITLE
Added support for label expressions provisioning & aquariumNodeInfo step

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ You can use the next steps in the pipeline:
      * `full: false` - partial snapshot, just the attached disks except for the root disk.
      * `full: true` - full snapshot including root disk and, if possible, memory of the running env.
 
+* `aquariumNodeInfo()`
+   Returns info about the currently running node in which the step is executed. Useful if your
+   pipeline wants to store it somewhere or use in the logic. The format is:
+   ```yaml
+   ApplicationInfo:
+     ApplicationUID: "<UUID>"
+     LabelName: "<name>"
+     LabelVersion: <version>
+   DefinitionInfo:  # See LabelDefinition in fish openapi yaml
+   ```
+
 ## Implementation
 
 The implementation is still PoC and not perfect in any way. For now it's mostly working.

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -98,6 +98,11 @@ public class AquariumClient {
         return c;
     }
 
+    public List<Label> labelGet() throws Exception {
+        startConnection();
+        return new LabelApi(api_client_pool.get(0)).labelListGet(null);
+    }
+
     public List<Label> labelFind(String name) throws Exception {
         startConnection();
         return new LabelApi(api_client_pool.get(0)).labelListGet("name='" + StringEscapeUtils.escapeSql(name) + "'");

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -12,6 +12,7 @@
 
 package com.adobe.ci.aquarium.net;
 
+import com.adobe.ci.aquarium.fish.client.ApiException;
 import com.adobe.ci.aquarium.fish.client.model.User;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -22,6 +23,7 @@ import com.google.common.util.concurrent.Futures;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.*;
+import hudson.model.labels.LabelAtom;
 import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner.PlannedNode;
@@ -61,6 +63,10 @@ public class AquariumCloud extends Cloud {
     private String jenkinsUrl;
     private String metadata;
     private List<LabelMapping> labelMappings = new ArrayList<>();
+
+    // A collection of labels supported by the Auqarium Fish cluster
+    private Set<LabelAtom> labelsCached;
+    private long labelsCachedUpdateTime = 0;
 
     @DataBoundConstructor
     public AquariumCloud(String name) {
@@ -134,16 +140,42 @@ public class AquariumCloud extends Cloud {
 
     @Override
     public boolean canProvision(Label label) {
-        LOG.log(Level.INFO, "Can provision label? : " + label.getName());
-        // TODO: Better to use some caching here, otherwise some lost
-        // connection tells jenkins to not use this cloud anymore
+        LOG.log(Level.INFO, "Can provision label expression? : " + label.toString());
         try {
-            return !(this.getClient().labelFind(label.getName()).isEmpty());
+            // Update the cache if time has come
+            if( this.labelsCachedUpdateTime < System.currentTimeMillis() ) {
+                this.updateLabelsCache();
+            }
+
+            // Simple comparison by label name
+            if( this.labelsCached.contains(label) )
+                return true;
+
+            // Match of the label expression
+            return label.matches(this.labelsCached);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         return false;
+    }
+
+    public void updateLabelsCache() throws Exception {
+        // Request all the labels supported by the cluster
+        Set<LabelAtom> out = new HashSet<>();
+        this.getClient().labelGet().forEach(label -> {
+            out.add(LabelAtom.get(label.getName()));
+        });
+
+        if( out.size() == 0 ) {
+            LOG.log(Level.WARNING, "Cluster contains no labels - empty list was returned");
+        }
+
+        // Replace the cached labels with newly received
+        this.labelsCached = out;
+
+        // Set the next labels update cache time to 30 mins from now
+        this.labelsCachedUpdateTime = System.currentTimeMillis() + 1800000;
     }
 
     private PlannedNode buildAgent(String label) {
@@ -182,16 +214,29 @@ public class AquariumCloud extends Cloud {
 
     @Override
     public Collection<PlannedNode> provision(Label label, int excessWorkload) {
-        LOG.log(Level.INFO, "Execute provision : " + label.getName() + ", workload: " + excessWorkload);
+        LOG.log(Level.INFO, "Execute provision : " + label.toString() + ", workload: " + excessWorkload);
 
         Set<String> allInProvisioning = getInProvisioning(label); // Nodes being launched
         LOG.log(Level.INFO, () -> "In provisioning : " + allInProvisioning);
         int toBeProvisioned = Math.max(0, excessWorkload - allInProvisioning.size());
         LOG.log(Level.INFO, "Label \"{0}\" excess workload: {1}", new Object[] {label, toBeProvisioned});
 
+        // Find first label that is matching to the requested expression
+        String label_name = "";
+        Set<LabelAtom> set = new HashSet<LabelAtom>();
+        for( LabelAtom l : this.labelsCached ) {
+            set.clear();
+            set.add(l);
+            if( label.matches(set) ) {
+                label_name = l.getName();
+                break;
+            }
+        }
+        LOG.log(Level.INFO, "Chosen label : " + label_name);
+
         List<PlannedNode> plannedNodes = new ArrayList<>();
-        while (toBeProvisioned > 0/* && Limits */) {
-            plannedNodes.add(buildAgent(label.getName()));
+        while( toBeProvisioned > 0 /* && Limits */ ) {
+            plannedNodes.add(buildAgent(label_name));
             toBeProvisioned--;
         }
         return plannedNodes;

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -12,7 +12,6 @@
 
 package com.adobe.ci.aquarium.net;
 
-import com.adobe.ci.aquarium.fish.client.ApiException;
 import com.adobe.ci.aquarium.fish.client.model.User;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumComputer.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumComputer.java
@@ -19,6 +19,7 @@ import hudson.model.queue.SubTask;
 import hudson.security.ACL;
 import hudson.security.Permission;
 import hudson.slaves.AbstractCloudComputer;
+import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.PlaceholderTask;
 
@@ -31,19 +32,26 @@ public class AquariumComputer extends AbstractCloudComputer<AquariumSlave> {
 
     private boolean launching;
 
-    private String app_info;
-    private String definition_info;
+    private JSONObject appInfo;
+    private JSONObject definitionInfo;
 
     public AquariumComputer(AquariumSlave slave) {
         super(slave);
     }
 
-    public void setAppInfo(String info) {
-        this.app_info = info;
+    public JSONObject getAppInfo() {
+        return this.appInfo;
+    }
+    public JSONObject getDefinitionInfo() {
+        return this.definitionInfo;
     }
 
-    public void setDefinitionInfo(String info) {
-        this.definition_info = info;
+    public void setAppInfo(JSONObject info) {
+        this.appInfo = info;
+    }
+
+    public void setDefinitionInfo(JSONObject info) {
+        this.definitionInfo = info;
     }
 
     @Override
@@ -59,17 +67,17 @@ public class AquariumComputer extends AbstractCloudComputer<AquariumSlave> {
             if( parent instanceof PlaceholderTask ) {
                 PlaceholderTask wf_run = (PlaceholderTask) parent;
                 PrintStream logger = wf_run.getNode().getExecution().getOwner().getListener().getLogger();
-                if( this.app_info != "" ) {
-                    logger.println("Aquarium Application: " + this.app_info);
+                if( !this.appInfo.isEmpty() ) {
+                    logger.println("Aquarium Application: " + this.appInfo);
                 }
-                if( this.definition_info != "" ) {
-                    logger.println("Aquarium Definition: " + this.definition_info);
+                if( !this.definitionInfo.isEmpty() ) {
+                    logger.println("Aquarium Definition: " + this.definitionInfo);
                 }
             } else {
-                LOG.log(Level.WARNING, "Incorrect definition or executor to notify: Aquarium LabelDefinition: " + this.definition_info);
+                LOG.log(Level.WARNING, "Incorrect definition or executor to notify: Aquarium LabelDefinition: " + this.definitionInfo);
             }
         } catch (Exception e) {
-            LOG.log(Level.WARNING, "Unable to notify task about node resource: Aquarium LabelDefinition: " + this.definition_info);
+            LOG.log(Level.WARNING, "Unable to notify task about node resource: Aquarium LabelDefinition: " + this.definitionInfo);
         }
     }
 

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
@@ -117,7 +117,7 @@ public class AquariumLauncher extends JNLPLauncher {
 
             // Wait for agent connection for 10 minutes
             int wait_agent_connect = 120; // 120 * 5 - status_call_time >= 10 mins
-            for(int waited_for_agent = 0; waited_for_agent < wait_agent_connect; waited_for_agent++ ) {
+            for( int waited_for_agent = 0; waited_for_agent < wait_agent_connect; waited_for_agent++ ) {
                 slaveComputer = node.getComputer();
                 if( slaveComputer == null ) {
                     throw new IllegalStateException("Node was deleted, computer is null");

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.TaskListener;
 import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
+import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -78,7 +79,11 @@ public class AquariumLauncher extends JNLPLauncher {
 
             // Notify computer log that the request for Application was sent
             listener.getLogger().println("Aquarium Application was requested: " + app.getUID() + " with Label: " + label.getName() + "#" + label.getVersion());
-            comp.setAppInfo("Application: " + app.getUID() + ", Label: " + label.getName() + "#" + label.getVersion());
+            JSONObject app_info = new JSONObject();
+            app_info.put("ApplicationUID", app.getUID().toString());
+            app_info.put("LabelName", label.getName());
+            app_info.put("LabelVersion", label.getVersion());
+            comp.setAppInfo(app_info);
 
             // Wait for fish node election process - it could take a while if there is not enough resources in the pool
             SlaveComputer slaveComputer;
@@ -113,7 +118,7 @@ public class AquariumLauncher extends JNLPLauncher {
             Resource res = client.applicationResourceGet(app.getUID());
             listener.getLogger().println("Aquarium LabelDefinition: " + label.getDefinitions().get(res.getDefinitionIndex()));
             // Tell computer to know where it runs
-            comp.setDefinitionInfo(label.getDefinitions().get(res.getDefinitionIndex()).toString());
+            comp.setDefinitionInfo(JSONObject.fromObject(label.getDefinitions().get(res.getDefinitionIndex())));
 
             // Wait for agent connection for 10 minutes
             int wait_agent_connect = 120; // 120 * 5 - status_call_time >= 10 mins

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumNodeInfoStep.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumNodeInfoStep.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.ci.aquarium.net.pipeline;
+
+import com.adobe.ci.aquarium.net.AquariumComputer;
+import com.adobe.ci.aquarium.net.AquariumSlave;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.slaves.SlaveComputer;
+import hudson.util.LogTaskListener;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AquariumNodeInfoStep extends Step implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor public AquariumNodeInfoStep() {}
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AquariumNodeInfoStepExecution(this, context);
+    }
+
+    public static class AquariumNodeInfoStepExecution extends SynchronousNonBlockingStepExecution<Object> {
+        private static final long serialVersionUID = 1L;
+        private static final transient Logger LOGGER = Logger.getLogger(AquariumNodeInfoStepExecution.class.getName());
+
+        private final AquariumNodeInfoStep step;
+
+        AquariumNodeInfoStepExecution(AquariumNodeInfoStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        private PrintStream logger() {
+            TaskListener l = null;
+            StepContext context = getContext();
+            try {
+                l = context.get(TaskListener.class);
+            } catch (Exception x) {
+                LOGGER.log(Level.WARNING, "Failed to find TaskListener in context");
+            } finally {
+                if (l == null) {
+                    l = new LogTaskListener(LOGGER, Level.FINE);
+                }
+            }
+            return l.getLogger();
+        }
+
+        @Override
+        protected Object run() throws Exception {
+            JSONObject json = null;
+            try {
+                LOGGER.log(Level.FINE, "Starting nodeInfo step.");
+
+                Node node = getContext().get(Node.class);
+                if( !(node instanceof AquariumSlave) ) {
+                    throw new AbortException(
+                            String.format("Node is not an Aquarium node: %s", node != null ? node.getNodeName() : null));
+                }
+
+                SlaveComputer comp = ((AquariumSlave) node).getComputer();
+                if( !(comp instanceof AquariumComputer) ) {
+                    throw new AbortException(
+                            String.format("Node is not an Aquarium computer: %s", comp != null ? comp.getName() : null));
+                }
+
+                JSONObject app_info = ((AquariumComputer) comp).getAppInfo();
+                JSONObject def_info = ((AquariumComputer) comp).getDefinitionInfo();
+                json.put("ApplicationInfo", app_info);
+                json.put("DefinitionInfo", def_info);
+            } catch (InterruptedException e) {
+                String msg = "Interrupted while getting node info from the node";
+                logger().println(msg);
+                LOGGER.log(Level.FINE, msg);
+            } catch (Exception e) {
+                String msg = "Failed to get node info from the node";
+                logger().println(msg);
+                LOGGER.log(Level.WARNING, msg, e);
+            }
+            return json;
+        }
+
+        @Override
+        public void stop(Throwable cause) throws Exception {
+            LOGGER.log(Level.FINE, "Stopping Aquarium NodeInfo step.");
+            super.stop(cause);
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "aquariumNodeInfo";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Get node info about the current node";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Node.class)));
+        }
+    }
+}

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumNodeInfoStep/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumNodeInfoStep/config.jelly
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:block>
+        <p>
+            Returns application, label and definition info of the current Aquarium Fish Application Resource.
+        </p>
+    </f:block>
+</j:jelly>


### PR DESCRIPTION
The change makes it possible to process the complex label expressions to choose the right Aquarium Fish Label and also adds an informational step `aquariumNodeInfo` in addition to the currently print-in-log info about the provisioned resource.

## Related Issue

fixes: #5 

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

