### PR TITLE
Fixed exception during showing Node settings and set exclusive for mode

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumSlave.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumSlave.java
@@ -65,6 +65,7 @@ public class AquariumSlave extends AbstractCloudSlave {
     protected AquariumSlave(String name, String nodeDescription, String cloudName, String labelStr,
                             ComputerLauncher computerLauncher) throws Descriptor.FormException, IOException {
         super(name, null, computerLauncher);
+        this.setMode(Mode.EXCLUSIVE);
         this.setNodeDescription(nodeDescription);
         this.setNumExecutors(1);
         this.setLabelString(labelStr);

--- a/src/main/resources/com/adobe/ci/aquarium/net/AquariumSlave/configure-entries.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/AquariumSlave/configure-entries.jelly
@@ -1,0 +1,31 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <div class="jenkins-section">
+    <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">
+      <f:textarea name="nodeDescription" value="${it.nodeDescription}" codemirror-mode="${app.markupFormatter.codeMirrorMode}" codemirror-config="${app.markupFormatter.codeMirrorConfig}" previewEndpoint="/markupFormatter/previewDescription"/>
+    </f:entry>
+  </div>
+
+  <f:entry title="Aquarium ApplicationUID">
+    <f:textarea name="applicationUID" value="${it.applicationUID}"/>
+  </f:entry>
+
+  <f:entry title="${%Number of executors}" field="numExecutors">
+    <f:number clazz="positive-number-required" min="1" step="1" default="1"/>
+  </f:entry>
+
+  <f:entry title="${%Remote root directory}" field="remoteFS">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="${%Labels}" field="labelString">
+    <f:textbox />
+  </f:entry>
+
+  <f:slave-mode name="mode" node="${it}" />
+
+  <f:descriptorList title="${%Node Properties}"
+                    descriptors="${descriptor.nodePropertyDescriptors(it)}"
+                    field="nodeProperties" />
+
+</j:jelly>


### PR DESCRIPTION
Now node configuration displays the general node parameters as well as ApplicationUID for reference. Also it makes the node exclusive - there is no reason to keep it available for not specific jobs that needs this specific worker.

## Related Issue

fixes: #19 

## Motivation and Context

Otherwise it shows exception there - not good.

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

<img width="873" alt="jenkins_node_settings" src="https://github.com/user-attachments/assets/f92fd424-fdbe-4873-9b57-ea6375090b08">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

