### PR TITLE
Added agent connect wait option and elected timeout

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -55,10 +55,13 @@ public class AquariumCloud extends Cloud {
 
     private static final Logger LOG = Logger.getLogger(AquariumCloud.class.getName());
 
+    private static final int DEFAULT_AGENT_CONNECTION_WAIT_MIN = 10;
+
     private String initHostUrl;
     @CheckForNull
     private String credentialsId;
     private String caCredentialsId;
+    private Integer agentConnectWaitMin;
     private String jenkinsUrl;
     private String metadata;
     private List<LabelMapping> labelMappings = new ArrayList<>();
@@ -74,30 +77,33 @@ public class AquariumCloud extends Cloud {
     }
 
     // Used by jelly
-    public String getName() {
-        return name;
+    public String getName() { return this.name; }
+
+    // Used by jelly
+    public String getInitHostUrl() { return this.initHostUrl; }
+
+    // Used by jelly
+    public String getCredentialsId() { return this.credentialsId; }
+
+    // Used by jelly
+    public String getCaCredentialsId() { return this.caCredentialsId; }
+
+    public int getAgentConnectWaitMin() {
+        if( this.agentConnectWaitMin == null || this.agentConnectWaitMin < 0 ) {
+            return DEFAULT_AGENT_CONNECTION_WAIT_MIN;
+        }
+        return this.agentConnectWaitMin.intValue();
     }
 
     // Used by jelly
-    public String getInitHostUrl() {
-        return initHostUrl;
-    }
+    public String getJenkinsUrl() { return this.jenkinsUrl; }
 
     // Used by jelly
-    public String getCredentialsId() { return credentialsId; }
-
-    // Used by jelly
-    public String getCaCredentialsId() { return caCredentialsId; }
-
-    // Used by jelly
-    public String getJenkinsUrl() { return jenkinsUrl; }
-
-    // Used by jelly
-    public String getMetadata() { return metadata; }
+    public String getMetadata() { return this.metadata; }
 
     // Used by jelly
     public List<LabelMapping> getLabelMappings() {
-        return labelMappings;
+        return this.labelMappings;
     }
 
     public AquariumClient getClient() {
@@ -111,12 +117,17 @@ public class AquariumCloud extends Cloud {
 
     @DataBoundSetter
     public void setCredentialsId(String value) {
-        credentialsId = Util.fixEmpty(value);
+        this.credentialsId = Util.fixEmpty(value);
     }
 
     @DataBoundSetter
     public void setCaCredentialsId(String value) {
-        caCredentialsId = Util.fixEmpty(value);
+        this.caCredentialsId = Util.fixEmpty(value);
+    }
+
+    @DataBoundSetter
+    public void setAgentConnectWaitMin(Integer value) {
+        this.agentConnectWaitMin = value;
     }
 
     @DataBoundSetter
@@ -126,7 +137,7 @@ public class AquariumCloud extends Cloud {
 
     @DataBoundSetter
     public void setMetadata(String value) {
-        metadata = Util.fixEmpty(value);
+        this.metadata = Util.fixEmpty(value);
     }
 
     @DataBoundSetter

--- a/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/config.jelly
@@ -18,6 +18,10 @@
         <c:select/>
     </f:entry>
 
+    <f:entry title="${%Agent Connect Wait Minutes}" field="agentConnectWaitMin">
+        <f:number/>
+    </f:entry>
+
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}"
                       method="testConnection" with="name,initHostUrl,credentialsId,caCredentialsId"/>
 

--- a/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/help-agentConnectWaitMin.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/help-agentConnectWaitMin.html
@@ -1,0 +1,1 @@
+<div>Minutes the launcher will wait for Agent connection after Application become ALLOCATED. After timeout if the agent did not connect back - launcher will delete the node and the process will start over if demand is still here.</div>


### PR DESCRIPTION
The change adds new parameter to the cloud configuration to set the timeout for agent connection. Before and by default it's set to 10 minutes. Also 5min timeout was added to fail the elected state (which usually should be relatively quick < 1 min).

## Related Issue

fixes: #15 

## Motivation and Context

Sometimes it's a good idea to tune agent timeout and never to wait forever in failed elected state.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

