### PR TITLE
Added action to show the available labels on Aquarium Cloud page

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -13,6 +13,7 @@
 package com.adobe.ci.aquarium.net;
 
 import com.adobe.ci.aquarium.fish.client.ApiClient;
+import com.adobe.ci.aquarium.fish.client.ApiException;
 import com.adobe.ci.aquarium.fish.client.api.ApplicationApi;
 import com.adobe.ci.aquarium.fish.client.api.LabelApi;
 import com.adobe.ci.aquarium.fish.client.api.UserApi;
@@ -98,7 +99,7 @@ public class AquariumClient {
         return c;
     }
 
-    public List<Label> labelGet() throws Exception {
+    public List<Label> labelGet() throws ApiException {
         startConnection();
         return new LabelApi(api_client_pool.get(0)).labelListGet(null);
     }

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -66,7 +66,7 @@ public class AquariumCloud extends Cloud {
     private String metadata;
     private List<LabelMapping> labelMappings = new ArrayList<>();
 
-    // A collection of labels supported by the Auqarium Fish cluster
+    // A collection of labels supported by the Aquarium Fish cluster
     private Set<LabelAtom> labelsCached;
     private long labelsCachedUpdateTime = 0;
 
@@ -92,7 +92,7 @@ public class AquariumCloud extends Cloud {
         if( this.agentConnectWaitMin == null || this.agentConnectWaitMin < 0 ) {
             return DEFAULT_AGENT_CONNECTION_WAIT_MIN;
         }
-        return this.agentConnectWaitMin.intValue();
+        return this.agentConnectWaitMin;
     }
 
     // Used by jelly

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloudLabelsAction.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloudLabelsAction.java
@@ -1,0 +1,81 @@
+package com.adobe.ci.aquarium.net;
+
+import com.adobe.ci.aquarium.fish.client.ApiException;
+import com.adobe.ci.aquarium.fish.client.model.Label;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Action;
+import jenkins.model.TransientActionFactory;
+import net.sf.json.JSONArray;
+import org.jetbrains.annotations.Nullable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import java.util.*;
+
+/**
+ * Attach available labels to the AquariumCloud status/index page
+ */
+@Restricted(NoExternalUse.class)
+public class AquariumCloudLabelsAction implements Action {
+    public final AquariumCloud cloud;
+
+    public AquariumCloudLabelsAction(AquariumCloud cloud) {
+        this.cloud = cloud;
+    }
+
+    // We don't need to display the menu item - just to show summary, so returning null for required methods
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    // Used in summary.jelly
+    public JSONArray getLabelsLatest(){
+        // Using SortedMap for in-place sorting
+        TreeMap<String, Label> latestLabels = new TreeMap<String, Label>();
+        try {
+            // TODO: For now getting all of them, but will need to switch to latest ones, when API will be here
+            List<Label> labels = cloud.getClient().labelGet();
+
+            // Filtering to keep only the latest ones
+            for( Label label : labels ) {
+                Label latestLabel = latestLabels.get(label.getName());
+                if( latestLabel == null || latestLabel.getVersion() < label.getVersion() ) {
+                    latestLabels.put(label.getName(), label);
+                }
+            }
+        } catch (ApiException e) {
+            throw new RuntimeException(e);
+        }
+        return JSONArray.fromObject(latestLabels.values());
+    }
+
+    @Extension
+    public static final class CloudActionFactory extends TransientActionFactory<AquariumCloud> {
+        @Override
+        public Class<AquariumCloud> type() {
+            return AquariumCloud.class;
+        }
+
+        @NonNull
+        @Override
+        public Collection<? extends Action> createFor(@NonNull AquariumCloud cloud) {
+            return Collections.singletonList(new AquariumCloudLabelsAction(cloud));
+        }
+    }
+}

--- a/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloudLabelsAction/summary.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloudLabelsAction/summary.jelly
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <h2>Aquarium Labels:</h2>
+    <table><tr><th>Label:Version</th><th>Created</th><th>Definition/Metadata</th></tr>
+        <j:forEach items="${it.labelsLatest}" var="label">
+            <tr><td><b>${label.get("name")}</b>:${label.get("version")}</td><td>${label.get("createdAt")}</td><td><f:advanced>
+                <p>Definitions:<pre>${label.getJSONArray("definitions").toString(2)}</pre></p>
+                <p>Metadata:<pre>${label.getJSONObject("metadata").toString(2)}</pre></p>
+            </f:advanced></td></tr>
+        </j:forEach>
+    </table>
+</j:jelly>


### PR DESCRIPTION
With this change we can see the available labels and their definitions right on the cloud status page of aquarium.

## Related Issue

fixes: #13 

## Motivation and Context

Support guys will use it to confirm the available labels without poking the API via curl

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

<img width="1286" alt="aquarium_status_labels_table" src="https://github.com/user-attachments/assets/543991ed-4a6f-4c09-bee9-7f919932857c">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

