### PR TITLE
Added channel close listener and interruption of the pipelines in case Aquarium was the cause

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCauseOfInterruption.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCauseOfInterruption.java
@@ -1,0 +1,46 @@
+package com.adobe.ci.aquarium.net;
+
+import com.adobe.ci.aquarium.fish.client.model.ApplicationStatus;
+import hudson.model.TaskListener;
+import jenkins.model.CauseOfInterruption;
+
+public class AquariumCauseOfInterruption extends CauseOfInterruption {
+    private static final long serialVersionUID = 1L;
+
+    private final ApplicationStatus status;
+    private final String description;
+
+    public AquariumCauseOfInterruption(ApplicationStatus status, String description) {
+        this.status = status;
+        this.description = description;
+    }
+
+    public ApplicationStatus getStatus() {
+        return status;
+    }
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Interrupted by Aquarium, Application State: " + status.toString() + ": " + description;
+    }
+
+    @Override
+    public void print(TaskListener listener) {
+        listener.getLogger().println(getShortDescription());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AquariumCauseOfInterruption that = (AquariumCauseOfInterruption) o;
+        return status.equals(that.status) && description.equals(that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return (status.toString()+description).hashCode();
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumChannelListener.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumChannelListener.java
@@ -1,0 +1,58 @@
+package com.adobe.ci.aquarium.net;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.adobe.ci.aquarium.fish.client.model.ApplicationState;
+import com.adobe.ci.aquarium.fish.client.model.ApplicationStatus;
+import hudson.model.Executor;
+import hudson.model.Result;
+import hudson.remoting.Channel;
+
+/**
+ * Class to listen for events in the computer channel and take measures in case anything goes wrong
+ */
+public class AquariumChannelListener extends Channel.Listener {
+
+    private static final Logger LOG = Logger.getLogger(AquariumChannelListener.class.getName());
+
+    AquariumComputer computer;
+
+    public AquariumChannelListener(AquariumComputer computer) {
+        this.computer = computer;
+    }
+
+    @Override
+    public void onClosed(Channel channel, IOException cause) {
+        // The channel was closed - let's find out the reason
+        AquariumCloud cloud;
+        if( computer == null || computer.getNode() == null ) {
+            // There is no node, so nothing is wrong
+            LOG.log(Level.FINE, "Channel is closed on computer: " + computer + " cause: " + cause);
+            return;
+        }
+        String app_uid = computer.getAppInfo().getString("ApplicationUID");
+        if( app_uid.isEmpty() ) {
+            LOG.log(Level.SEVERE, "Unable to locate ApplicationUID for computer: " + computer);
+            return;
+        }
+        ApplicationState state;
+        try {
+            state = computer.getNode().getAquariumCloud().getClient().applicationStateGet(UUID.fromString(app_uid));
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Unable to request ApplicationState for ApplicationUID " + app_uid + " reason: " + e);
+            return;
+        }
+        LOG.log(Level.WARNING, "Channel is closed on Computer: " + computer + " with ApplicationUID: " + app_uid + ", State: " + state.getStatus() + ": " + state.getDescription() + ", Cause: " + cause);
+        computer.getListener().getLogger().println("AquariumChannelListener remote disconnected: ApplicationUID: " + app_uid + ", State: " + state.getStatus() + ": " + state.getDescription() + ", Cause: " + cause);
+
+        if( state.getStatus() == ApplicationStatus.ALLOCATED ) {
+            // Aborting all the executors since the Application was deallocated
+            for (Executor exec : computer.getAllExecutors()) {
+                exec.interrupt(Result.ABORTED, new AquariumCauseOfInterruption(state.getStatus(), state.getDescription()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -31,6 +31,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
+import org.jetbrains.annotations.NotNull;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -48,8 +49,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
-
-class ServiceInstance {}
 
 public class AquariumCloud extends Cloud {
 
@@ -150,6 +149,7 @@ public class AquariumCloud extends Cloud {
 
     @Override
     public boolean canProvision(Label label) {
+        LOG.log(Level.FINEST, "Can provision label? " + label.toString());
         try {
             // Update the cache if time has come
             if( this.labelsCachedUpdateTime < System.currentTimeMillis() ) {
@@ -176,7 +176,7 @@ public class AquariumCloud extends Cloud {
             out.add(LabelAtom.get(label.getName()));
         });
 
-        if( out.size() == 0 ) {
+        if( out.isEmpty() ) {
             LOG.log(Level.WARNING, "Cluster contains no labels - empty list was returned");
         }
 
@@ -264,10 +264,6 @@ public class AquariumCloud extends Cloud {
         return "AquariumCloud {Name='" + name + "'}";
     }
 
-    public ServiceInstance getSI() {
-        return new ServiceInstance();
-    }
-
     public void onTerminate(AquariumSlave slave) {
     }
 
@@ -279,6 +275,7 @@ public class AquariumCloud extends Cloud {
     @Extension
     public static final class DescriptorImpl extends Descriptor<Cloud> {
 
+        @NotNull
         @Override
         public String getDisplayName() {
             return "Aquarium";
@@ -340,8 +337,7 @@ public class AquariumCloud extends Cloud {
                     ACL.SYSTEM,
                     context,
                     StandardCredentials.class,
-                    serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build()
-                            : Collections.EMPTY_LIST,
+                    serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build() : Collections.emptyList(),
                     CredentialsMatchers.anyOf(
                             CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class)
                     )
@@ -359,8 +355,7 @@ public class AquariumCloud extends Cloud {
                     ACL.SYSTEM,
                     context,
                     StandardCredentials.class,
-                    serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build()
-                            : Collections.EMPTY_LIST,
+                    serverUrl != null ? URIRequirementBuilder.fromUri(serverUrl).build() : Collections.emptyList(),
                     CredentialsMatchers.anyOf(
                             CredentialsMatchers.instanceOf(FileCredentials.class)
                     )

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumComputer.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumComputer.java
@@ -22,6 +22,7 @@ import hudson.slaves.AbstractCloudComputer;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.PlaceholderTask;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.PrintStream;
 import java.util.logging.Level;
@@ -120,12 +121,13 @@ public class AquariumComputer extends AbstractCloudComputer<AquariumSlave> {
         return String.format("AquariumComputer name: %s slave: %s", getName(), getNode());
     }
 
+    @NotNull
     @Override
     public ACL getACL() {
         final ACL base = super.getACL();
         return new ACL() {
             @Override
-            public boolean hasPermission(Authentication a, Permission permission) {
+            public boolean hasPermission(@NotNull Authentication a, @NotNull Permission permission) {
                 return permission == Computer.CONFIGURE ? false : base.hasPermission(a,permission);
             }
         };

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
@@ -78,7 +78,7 @@ public class AquariumLauncher extends JNLPLauncher {
             node.setApplicationUID(app.getUID());
 
             // Notify computer log that the request for Application was sent
-            listener.getLogger().println("Aquarium Application was requested: " + app.getUID() + " with Label: " + label.getName() + "#" + label.getVersion());
+            listener.getLogger().println("Aquarium Application was requested: " + app.getUID() + " with Label: " + label.getName() + ":" + label.getVersion());
             JSONObject app_info = new JSONObject();
             app_info.put("ApplicationUID", app.getUID().toString());
             app_info.put("LabelName", label.getName());
@@ -166,6 +166,15 @@ public class AquariumLauncher extends JNLPLauncher {
             // agent termination if no workload was assigned to it.
             node.setRetentionStrategy(new OnceRetentionStrategy(5));
 
+            // Adding listener to the channel to catch any kind of interruptions
+            if( computer.getChannel() != null ) {
+                computer.getChannel().addListener(new AquariumChannelListener(comp));
+            } else {
+                LOG.log(Level.WARNING, "Unable to set channel listener since channel is null");
+            }
+            // Print data again because was cleaned when agent connected
+            listener.getLogger().println("Aquarium Application: " + app.getUID() + " with Label: " + label.getName() + ":" + label.getVersion());
+            listener.getLogger().println("Aquarium LabelDefinition: " + label.getDefinitions().get(res.getDefinitionIndex()));
             computer.setAcceptingTasks(true);
             launched = true;
 


### PR DESCRIPTION
With this change on any channel close plugin will check if the cause is Aquarium (timeout or any other issue with application state) and will notify pipeline in this case. Otherwise it will just wait because the closed channel could mean that agent temporarily disconnected.

Also the change contains some cleanups and small fixes.

## Related Issue

fixes: #18 

## Motivation and Context

Make it better

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

