### PR TITLE
Added an ability to specify label version using colon separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ If you want to use custom Fish OpenAPI specification during the build - just set
 
 Just install it to your jenkins, specify some Aquarium Fish node API address and choose credentials.
 The plugin will automatically connect to the cluster, receive the other nodes addresses to maintain
-reliable connection, get the cluster labels configuration and will allow to edit them as needed (if
-the user you use have permissions to do that).
+reliable connection, get the cluster labels configuration and will allow to use them as needed.
+
+To utilize the Label you must specify it as name for your node or label expression. Also you can
+use specific version of the label by adding suffix with colon and number to the label name like
+`your-label-name:55` - so your release build will be pinned to the version of the build environment
+forever.
 
 Now when the build will be added to queue - if the cluster have the label in stock and the limits
 are met the plugin will create the node to allow connect the jenkins and place the resource request
-in the cluster.
+(Application) in the cluster.
 
 Aquarium Fish cluster will decide which node can handle the resource request, run the resource and
 connect to the created agent node to serve the build needs.
@@ -46,6 +50,13 @@ You can use the next steps in the pipeline:
    will be captured really depends on the used driver, but in general the rules are:
      * `full: false` - root image, just the root disk without the attached disks.
      * `full: true` - full image including all the disks.
+
+* `aquariumApplicationTask(taskUid: 'UUID')` (`wait: false`)
+   Allows to figure out the task info and result. This step doesn't want to be executed directly
+   on the aquarium worker - so you can safely move on the pipeline without agent and wait there for
+   your previous snapshot/image is created. Step requires just one parameter - is UUID string that
+   you can get after execution of aquariumCreateSnapshot/aquariumCreateImage steps. Wait param will
+   allow to block the pipeline until the result of the task become available.
 
 * `aquariumApplicationInfo()`
    Returns info about the currently running node in which the step is executed. Useful if your

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -27,6 +27,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -107,6 +108,13 @@ public class AquariumClient {
     public List<Label> labelFind(String name) throws ApiException {
         startConnection();
         return new LabelApi(api_client_pool.get(0)).labelListGet("name='" + StringEscapeUtils.escapeSql(name) + "'");
+    }
+
+    @Nullable
+    public Label labelVersionFind(String name, Integer version) throws ApiException {
+        startConnection();
+        List<Label> lst = new LabelApi(api_client_pool.get(0)).labelListGet("name='" + StringEscapeUtils.escapeSql(name) + "' AND version=" + version);
+        return lst.isEmpty() ? null : lst.get(0);
     }
 
     public Label labelFindLatest(String name) throws Exception {

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumLauncher.java
@@ -62,11 +62,28 @@ public class AquariumLauncher extends JNLPLauncher {
 
         LOG.log(Level.INFO, "Launch node" + comp.getName());
 
+        String nodeFirstLabel = node.getLabelString().split(" ")[0];
         try {
             // Request for resource
             AquariumCloud cloud = node.getAquariumCloud();
             AquariumClient client = cloud.getClient();
-            Label label = client.labelFindLatest(node.getLabelString().split(" ")[0]);
+            Label label = null;
+
+            // Checking if label contains version
+            int colonPos = nodeFirstLabel.indexOf(':');
+            if( colonPos > 0 ) {
+                // Label name contains version, so getting the required label version
+
+                String labelName = nodeFirstLabel.substring(0, colonPos);
+                Integer labelVersion = Integer.parseInt(nodeFirstLabel.substring(colonPos+1));
+                label = client.labelVersionFind(labelName, labelVersion);
+            } else {
+                // No version in the label, so using latest one
+                label = client.labelFindLatest(nodeFirstLabel);
+            }
+            if( label == null) {
+                throw new IllegalStateException("Label was not found in Aquarium: " + nodeFirstLabel);
+            }
             Application app = client.applicationCreate(
                     label.getUID(),
                     cloud.getJenkinsUrl(),


### PR DESCRIPTION
With this change releases can bind to specific version of the label to be rebuilt at the same environment. To specify the version just add colon and version number to the label name.

## Related Issue

fixes: #17 

## Motivation and Context

Releases need to be pinned to environment version.

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

