### PR TITLE
Fixed issue with jenkins master restart while the Aquarium node is still here

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -161,6 +161,11 @@ public class AquariumClient {
         return new ApplicationApi(api_client_pool.get(0)).applicationCreatePost(app);
     }
 
+    public Application applicationGet(UUID app_uid) throws Exception {
+        startConnection();
+        return new ApplicationApi(api_client_pool.get(0)).applicationGet(app_uid);
+    }
+
     public ApplicationState applicationStateGet(UUID app_uid) throws Exception {
         startConnection();
         return new ApplicationApi(api_client_pool.get(0)).applicationStateGet(app_uid);


### PR DESCRIPTION
Now Aquarium launcher knows that it can be started again on existing node, so will not try to create another Applicatio, will wait for the agent connection and continue pipeline execution if possible.

## Related Issue

fixes: #25 

## Motivation and Context

Bugfix

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

<img width="996" alt="aquarium_job_jenkins_restart" src="https://github.com/user-attachments/assets/1c7d0536-e1c9-481d-b1b7-67be4910a2fd">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

