### PR TITLE
Removed action on disconnected agent for now to not kill the entire pipeline

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumChannelListener.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumChannelListener.java
@@ -48,11 +48,13 @@ public class AquariumChannelListener extends Channel.Listener {
         LOG.log(Level.WARNING, "Channel is closed on Computer: " + computer + " with ApplicationUID: " + app_uid + ", State: " + state.getStatus() + ": " + state.getDescription() + ", Cause: " + cause);
         computer.getListener().getLogger().println("AquariumChannelListener remote disconnected: ApplicationUID: " + app_uid + ", State: " + state.getStatus() + ": " + state.getDescription() + ", Cause: " + cause);
 
-        if( state.getStatus() == ApplicationStatus.ALLOCATED ) {
+        if( state.getStatus() != ApplicationStatus.ALLOCATED ) {
             // Aborting all the executors since the Application was deallocated
-            for (Executor exec : computer.getAllExecutors()) {
+            // TODO: Skipping the action for now to not kill the entire pipeline
+            LOG.log(Level.WARNING, "Not killing the pipeline to prevent the entire pipeline to die: " + computer + " with ApplicationUID: " + app_uid);
+            /*for (Executor exec : computer.getAllExecutors()) {
                 exec.interrupt(Result.ABORTED, new AquariumCauseOfInterruption(state.getStatus(), state.getDescription()));
-            }
+            }*/
         }
     }
 }


### PR DESCRIPTION
During big testing after deployment found there is a logical error in the listener and action actually sends abort to the entire pipeline rather then just one thread executed on computer. Will need to rethink it further in #18, but for now disabled the action so only log is here.

## Related Issue

#18

## Motivation and Context

Bug was found

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

