### PR TITLE
Hotfix for the issue with client timeouts - 10s is too quick

### DIFF
--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -55,6 +55,9 @@ public class AquariumClient {
             cl.setBasePath(this.node_url);
             cl.setUsername(getBasicAuthCreds(this.cred_id).getUsername());
             cl.setPassword(getBasicAuthCreds(this.cred_id).getPassword().getPlainText());
+            cl.setConnectTimeout(300000); // 5 min
+            cl.setWriteTimeout(300000); // 5 min
+            cl.setReadTimeout(300000); // 5 min
             if( this.ca_cert_id == null || this.ca_cert_id.isEmpty() ) {
                 cl.setVerifyingSsl(false);
             } else {


### PR DESCRIPTION
By default timeout is set to 10s and when fish node is busy - it triggers a cycle of death, where the created nodes becomes old and obsolete - because their instances already destroyed but thay can't be deleted due to the  timeout of the request. 5 mins is a safety precaution, until we will find a better way.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

