### PR TITLE
ANJ-36 Completed circle to allow to create labels from pipeline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
+aquarium_fish_version=$(mvn --batch-mode help:evaluate -Dexpression=aquarium-fish-java.version -q -DforceStdout)
 if [ ! -f "aquarium-fish-java-shaded-${aquarium_fish_version}.jar" ]; then
-    aquarium_fish_version=$(mvn --batch-mode help:evaluate -Dexpression=aquarium-fish-java.version -q -DforceStdout)
-
     echo 'Download and install release artifact from github'
     curl -sLo "aquarium-fish-java-shaded-${aquarium_fish_version}.jar" "https://github.com/adobe/aquarium-fish/releases/download/v${aquarium_fish_version}/aquarium-fish-java-${aquarium_fish_version}-shaded.jar"
     mvn --batch-mode install:install-file -Dfile=aquarium-fish-java-shaded-${aquarium_fish_version}.jar -DgroupId=com.adobe.ci.aquarium -DartifactId=aquarium-fish-java -Dversion=${aquarium_fish_version} -Dclassifier=shaded -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.adobe.ci.aquarium</groupId>
     <artifactId>aquarium-net-jenkins</artifactId>
-    <version>0.6.0</version><!-- Replaced during release from git tag -->
+    <version>dev-SNAPSHOT</version><!-- Replaced during release from git tag -->
     <packaging>hpi</packaging>
     <name>Aquarium Net Jenkins Plugin</name>
     <description>Dynamically allocates required resources from Aquarium Fish cluster nodes</description>

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumClient.java
@@ -500,6 +500,27 @@ public class AquariumClient {
     }
 
     /**
+     * Create a new label via streaming
+     */
+    public String createLabel(LabelOuterClass.Label labelProto) throws Exception {
+        LabelOuterClass.LabelServiceCreateRequest request = LabelOuterClass.LabelServiceCreateRequest.newBuilder()
+                .setLabel(labelProto)
+                .build();
+
+        Streaming.StreamingServiceConnectResponse response = sendStreamRequest("LabelServiceCreateRequest",
+            com.google.protobuf.Any.pack(request));
+
+        LabelOuterClass.LabelServiceCreateResponse labelResponse = response.getResponseData()
+            .unpack(LabelOuterClass.LabelServiceCreateResponse.class);
+
+        if (!labelResponse.getStatus()) {
+            throw new RuntimeException("Failed to create label: " + labelResponse.getMessage());
+        }
+
+        return labelResponse.getData().getUid();
+    }
+
+    /**
      * Deallocate an application via streaming
      */
     public void deallocateApplication(String applicationUid) throws Exception {

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -117,6 +117,7 @@ public class AquariumCloud extends Cloud {
         this.jenkinsUrl = config.getJenkinsUrl();
         this.metadata = config.getAdditionalMetadata();
         this.labelFilter = config.getLabelFilter();
+        this.labelTemplates = config.getLabelTemplates();
         LOG.info("STARTING Aquarium CLOUD with config");
         // In integration tests, avoid background reconnection to keep test isolation
         this.reconnectClient = false;

--- a/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/AquariumCloud.java
@@ -15,6 +15,7 @@
 package com.adobe.ci.aquarium.net;
 
 import com.adobe.ci.aquarium.net.config.AquariumCloudConfiguration;
+import com.adobe.ci.aquarium.net.config.AquariumLabelTemplate;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -75,6 +76,7 @@ public class AquariumCloud extends Cloud {
     private String metadata;
     private String labelFilter;
     private List<LabelMapping> labelMappings = new ArrayList<>();
+    private List<AquariumLabelTemplate> labelTemplates = new ArrayList<>();
 
     // A collection of labels supported by the Aquarium Fish cluster
     private transient Map<String, com.adobe.ci.aquarium.net.model.Label> fishLabelsCache = new ConcurrentHashMap<>();
@@ -221,10 +223,10 @@ public class AquariumCloud extends Cloud {
 
             @Override
             public void onLabelRemoved(String labelUid) {
-                com.adobe.ci.aquarium.net.model.Label removed = fishLabelsCache.remove(labelUid);
-                if (removed != null) {
+                com.adobe.ci.aquarium.net.model.Label label = fishLabelsCache.remove(labelUid);
+                if (label != null) {
                     updateJenkinsLabelsCache();
-                    LOG.log(Level.INFO, "Removed Fish label: " + removed.getName() + ":" + removed.getVersion() + " (" + removed.getUid() + ")");
+                    LOG.log(Level.INFO, "Removed Fish label: " + label.getName() + ":" + label.getVersion() + " (" + label.getUid() + ")");
                 }
             }
         });
@@ -331,6 +333,11 @@ public class AquariumCloud extends Cloud {
     // Used by jelly
     public List<LabelMapping> getLabelMappings() {
         return this.labelMappings;
+    }
+
+    // Used by jelly
+    public List<AquariumLabelTemplate> getLabelTemplates() {
+        return this.labelTemplates;
     }
 
     // Used by AquariumCloudLabelsAction
@@ -541,6 +548,14 @@ public class AquariumCloud extends Cloud {
         this.labelMappings = new ArrayList<>();
         if( labels != null ) {
             this.labelMappings.addAll(labels);
+        }
+    }
+
+    @DataBoundSetter
+    public void setLabelTemplates(@CheckForNull List<AquariumLabelTemplate> templates) {
+        this.labelTemplates = new ArrayList<>();
+        if( templates != null ) {
+            this.labelTemplates.addAll(templates);
         }
     }
 

--- a/src/main/java/com/adobe/ci/aquarium/net/config/AquariumCloudConfiguration.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/config/AquariumCloudConfiguration.java
@@ -39,6 +39,7 @@ public class AquariumCloudConfiguration {
     private final String jenkinsUrl;
     private final String additionalMetadata;
     private final String labelFilter;
+    private final java.util.List<AquariumLabelTemplate> labelTemplates;
 
     @DataBoundConstructor
     public AquariumCloudConfiguration(boolean enabled,
@@ -48,7 +49,8 @@ public class AquariumCloudConfiguration {
                                     int agentConnectionWaitMinutes,
                                     String jenkinsUrl,
                                     String additionalMetadata,
-                                    String labelFilter) {
+                                    String labelFilter,
+                                    java.util.List<AquariumLabelTemplate> labelTemplates) {
         this.enabled = enabled;
         this.initAddress = initAddress;
         this.credentialsId = credentialsId;
@@ -57,6 +59,7 @@ public class AquariumCloudConfiguration {
         this.jenkinsUrl = jenkinsUrl;
         this.additionalMetadata = additionalMetadata;
         this.labelFilter = labelFilter;
+        this.labelTemplates = labelTemplates != null ? new java.util.ArrayList<>(labelTemplates) : new java.util.ArrayList<>();
     }
 
     // Getters
@@ -150,6 +153,10 @@ public class AquariumCloudConfiguration {
         return labelFilter;
     }
 
+    public java.util.List<AquariumLabelTemplate> getLabelTemplates() {
+        return new java.util.ArrayList<>(labelTemplates);
+    }
+
     /**
      * Builder pattern for creating configuration instances
      */
@@ -162,6 +169,7 @@ public class AquariumCloudConfiguration {
         private String jenkinsUrl;
         private String additionalMetadata;
         private String labelFilter;
+        private java.util.List<AquariumLabelTemplate> labelTemplates = new java.util.ArrayList<>();
 
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
@@ -203,11 +211,16 @@ public class AquariumCloudConfiguration {
             return this;
         }
 
+        public Builder labelTemplates(java.util.List<AquariumLabelTemplate> labelTemplates) {
+            this.labelTemplates = labelTemplates != null ? new java.util.ArrayList<>(labelTemplates) : new java.util.ArrayList<>();
+            return this;
+        }
+
         public AquariumCloudConfiguration build() {
             return new AquariumCloudConfiguration(
                 enabled, initAddress, credentialsId,
                 certificateId, agentConnectionWaitMinutes, jenkinsUrl,
-                additionalMetadata, labelFilter
+                additionalMetadata, labelFilter, labelTemplates
             );
         }
     }

--- a/src/main/java/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2024-2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Author: Sergei Parshev (@sparshev)
+
+package com.adobe.ci.aquarium.net.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Configuration for Aquarium label templates used in pipeline steps.
+ * Templates allow reusable label definitions with variable substitution.
+ */
+public class AquariumLabelTemplate extends AbstractDescribableImpl<AquariumLabelTemplate> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String id;
+    private String name;
+    private String description;
+    private String templateContent;
+
+    @DataBoundConstructor
+    public AquariumLabelTemplate(String id, String name, String templateContent) {
+        this.id = id;
+        this.name = name;
+        this.templateContent = templateContent;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @DataBoundSetter
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @DataBoundSetter
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTemplateContent() {
+        return templateContent;
+    }
+
+    @DataBoundSetter
+    public void setTemplateContent(String templateContent) {
+        this.templateContent = templateContent;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<AquariumLabelTemplate> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Aquarium Label Template";
+        }
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/config/TemplateVariable.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/config/TemplateVariable.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2024-2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Author: Sergei Parshev (@sparshev)
+
+package com.adobe.ci.aquarium.net.config;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Simple key-value pair for template variables
+ */
+public class TemplateVariable extends AbstractDescribableImpl<TemplateVariable> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String key;
+    private final String value;
+
+    @DataBoundConstructor
+    public TemplateVariable(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<TemplateVariable> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Template Variable";
+        }
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2024-2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Author: Sergei Parshev (@sparshev)
+
+package com.adobe.ci.aquarium.net.pipeline;
+
+import com.adobe.ci.aquarium.net.AquariumCloud;
+import com.adobe.ci.aquarium.net.config.TemplateVariable;
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.util.ListBoxModel;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import jenkins.model.Jenkins;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+
+public class AquariumCreateLabelStep extends Step implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String templateId;
+    private List<TemplateVariable> variables;
+
+    @DataBoundConstructor
+    public AquariumCreateLabelStep(String templateId) {
+        this.templateId = templateId;
+        this.variables = new ArrayList<>();
+    }
+
+    @DataBoundSetter
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
+    }
+
+    @DataBoundSetter
+    public void setVariables(List<TemplateVariable> variables) {
+        this.variables = variables != null ? new ArrayList<>(variables) : new ArrayList<>();
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public List<TemplateVariable> getVariables() {
+        return new ArrayList<>(variables);
+    }
+
+    public Map<String, String> getVariablesAsMap() {
+        Map<String, String> result = new HashMap<>();
+        if (variables != null) {
+            for (TemplateVariable var : variables) {
+                if (var.getKey() != null && var.getValue() != null) {
+                    result.put(var.getKey(), var.getValue());
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new AquariumCreateLabelStepExecution(this, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "aquariumCreateLabel";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Create Aquarium Label from Template";
+        }
+
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Node.class)));
+        }
+
+        // Used to fill the pipeline step snippet generator `templateId` field
+        public ListBoxModel doFillTemplateIdItems() {
+            ListBoxModel items = new ListBoxModel();
+            items.add("Select template...", "");
+
+            // Get all available templates from all Aquarium clouds
+            for (hudson.slaves.Cloud cloud : Jenkins.get().clouds) {
+                if (cloud instanceof AquariumCloud) {
+                    AquariumCloud aquariumCloud = (AquariumCloud) cloud;
+                    List<com.adobe.ci.aquarium.net.config.AquariumLabelTemplate> templates = aquariumCloud.getLabelTemplates();
+                    if (templates != null) {
+                        for (com.adobe.ci.aquarium.net.config.AquariumLabelTemplate template : templates) {
+                            items.add(template.getName() + " (" + aquariumCloud.getName() + ")", template.getId());
+                        }
+                    }
+                }
+            }
+
+            return items;
+        }
+    }
+}

--- a/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep.java
+++ b/src/main/java/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep.java
@@ -17,7 +17,6 @@ package com.adobe.ci.aquarium.net.pipeline;
 import com.adobe.ci.aquarium.net.AquariumCloud;
 import com.adobe.ci.aquarium.net.config.TemplateVariable;
 import hudson.Extension;
-import hudson.model.Node;
 import hudson.util.ListBoxModel;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -106,7 +105,7 @@ public class AquariumCreateLabelStep extends Step implements Serializable {
 
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
-            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Node.class)));
+            return Collections.unmodifiableSet(new HashSet<>());
         }
 
         // Used to fill the pipeline step snippet generator `templateId` field

--- a/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/AquariumCloud/config.jelly
@@ -45,4 +45,9 @@
         <f:repeatableHeteroProperty field="labelMappings" hasHeader="true" addCaption="${%Add Label Mapping}"
                                     deleteCaption="${%Delete Label Mapping}" />
     </f:entry>
+
+    <f:entry title="${%Label Templates}" field="labelTemplates">
+        <f:repeatableHeteroProperty field="labelTemplates" hasHeader="true" addCaption="${%Add Label Template}"
+                                    deleteCaption="${%Delete Label Template}" />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/config.jelly
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="id" title="Template ID">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="name" title="Template Name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="description" title="Description">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="templateContent" title="Template Content (YAML)">
+        <f:textarea rows="20" cols="80"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-description.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-description.html
@@ -1,0 +1,3 @@
+<div>
+    Optional description of what this template is used for and what variables it expects.
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-id.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-id.html
@@ -1,0 +1,3 @@
+<div>
+    Unique identifier for this template. This ID will be used in pipeline steps to reference this template.
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-name.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-name.html
@@ -1,0 +1,3 @@
+<div>
+    Human-readable name for this template. This will be displayed in the pipeline step configuration.
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-templateContent.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help-templateContent.html
@@ -1,0 +1,4 @@
+<div>
+    YAML content that defines the Aquarium Label. Use <code>${variableName}</code> syntax for variables that will be substituted at runtime.
+    The YAML structure should match the Aquarium Label proto definition.
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/AquariumLabelTemplate/help.html
@@ -1,0 +1,38 @@
+<div>
+    <p>Configure Aquarium Label Templates for use in pipeline steps.</p>
+
+    <p><strong>Template Content</strong> should be valid YAML that defines an Aquarium Label. You can use variables like <code>${variableName}</code> that will be substituted when the template is used.</p>
+
+    <p><strong>Predefined Variables:</strong></p>
+    <ul>
+        <li><code>${TIMESTAMP}</code> - Current timestamp in format YYMMDD.hhmmss</li>
+        <li><code>${NOW+N*UNIT}</code> - Current time plus offset (e.g., ${NOW+3*HOUR})</li>
+    </ul>
+
+    <p><strong>Example Template:</strong></p>
+    <pre>
+name: temp_ci-${name}-${TIMESTAMP}
+version: 0
+visible_for:
+  - jenkins
+  - jenkins-group
+remove_at: '${NOW+3*HOUR}'
+definitions:
+  - driver: aws
+    images:
+      - name: '${image}'
+    options:
+      instance_type: g4ad.8xlarge
+      security_groups:
+        - supergroup1
+        - supergroup2
+      userdata_format: env
+    resources:
+      cpu: 32
+      ram: 128
+      network: Subnet:build
+      lifetime: 4h
+metadata:
+  JENKINS_AGENT_WORKSPACE: /mnt/ws
+    </pre>
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/config/TemplateVariable/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/config/TemplateVariable/config.jelly
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="key" title="Variable Name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="value" title="Variable Value">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/config.jelly
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/config.jelly
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:block>
+        <p>
+            Creates an Aquarium Label from a predefined template with variable substitution.
+            The template can contain variables like ${name}, ${image}, and predefined variables like ${TIMESTAMP} and ${NOW+3*HOUR}.
+        </p>
+    </f:block>
+    <f:entry field="templateId" title="Label Template">
+        <f:select/>
+    </f:entry>
+    <f:entry field="variables" title="Template Variables">
+        <f:repeatableHeteroProperty field="variables" hasHeader="true" addCaption="Add Variable" deleteCaption="Delete Variable"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help-templateId.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help-templateId.html
@@ -1,0 +1,3 @@
+<div>
+    Select the template ID from the dropdown. Templates are defined in the Aquarium Cloud configuration.
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help-variables.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help-variables.html
@@ -1,0 +1,6 @@
+<div>
+    Provide values for variables used in the template. Variables are referenced in templates using ${variableName} syntax.
+    If a required variable is not provided, the pipeline step will fail with an error message.
+
+    <p>Each variable consists of a name (key) and its corresponding value that will be substituted in the template.</p>
+</div>

--- a/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help.html
+++ b/src/main/resources/com/adobe/ci/aquarium/net/pipeline/AquariumCreateLabelStep/help.html
@@ -1,0 +1,11 @@
+<div>
+    Creates an Aquarium Label from a predefined template. Select a template and provide values for any variables defined in the template.
+    <br/><br/>
+    <strong>Predefined Variables:</strong>
+    <ul>
+        <li><code>${TIMESTAMP}</code> - Current timestamp in format YYMMDD.hhmmss</li>
+        <li><code>${NOW+N*UNIT}</code> - Current time plus offset (e.g., ${NOW+3*HOUR} for 3 hours from now)</li>
+    </ul>
+
+    <strong>Supported time units:</strong> SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, YEAR
+</div>

--- a/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumCreateLabelStepIT.java
+++ b/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumCreateLabelStepIT.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Author: Sergei Parshev (@sparshev)
+
+package com.adobe.ci.aquarium.net.integration;
+
+import com.adobe.ci.aquarium.net.AquariumCloud;
+import com.adobe.ci.aquarium.net.config.AquariumCloudConfiguration;
+import com.adobe.ci.aquarium.net.config.AquariumLabelTemplate;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import java.util.logging.Level;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class AquariumCreateLabelStepIT {
+
+    @Rule
+    public LoggerRule logger = new LoggerRule().record("com.adobe.ci.aquarium", Level.ALL);
+
+    @Rule
+    public AquariumFishTestHelper fishHelper = new AquariumFishTestHelper();
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testCreateLabelPipelineStep() throws Exception {
+        fishHelper.startFishNode(null);
+
+        assertTrue("Fish must be running", fishHelper.isRunning());
+        // Create an advanced test user
+        fishHelper.createAdvancedTestUser();
+
+        String labelUid = fishHelper.createTestLabel();
+        assertNotNull(labelUid);
+
+        // Create label templates for testing
+        List<AquariumLabelTemplate> templates = createTestLabelTemplates();
+
+        AquariumCloudConfiguration config = fishHelper.getPluginConfig(j);
+        AquariumCloudConfiguration configWithTemplates = new AquariumCloudConfiguration.Builder()
+                .enabled(config.isEnabled())
+                .initAddress(config.getInitAddress())
+                .credentialsId(config.getCredentialsId())
+                .certificateId(config.getCertificateId())
+                .agentConnectionWaitMinutes(config.getAgentConnectionWaitMinutes())
+                .jenkinsUrl(config.getJenkinsUrl())
+                .additionalMetadata(config.getAdditionalMetadata())
+                .labelFilter(config.getLabelFilter())
+                .labelTemplates(templates)
+                .build();
+
+        AquariumCloud cloud = new AquariumCloud("create-label-test-cloud", configWithTemplates);
+        Jenkins jenkins = j.getInstance();
+        jenkins.clouds.add(cloud);
+
+        Thread.sleep(3000);
+        assertTrue("Cloud should connect", cloud.isConnected());
+
+        // Create a Pipeline job that uses the aquariumCreateLabel step
+        WorkflowJob job = j.createProject(WorkflowJob.class, "create-label-pipeline");
+
+        String jenkinsfile = "" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('Create Label Test') {\n" +
+                "      agent { label 'jenkins-test-label' }\n" +
+                "      stages {\n" +
+                "        stage('Create Label with Variables') {\n" +
+                "          steps {\n" +
+                "            script {\n" +
+                "              def labelUid = aquariumCreateLabel(\n" +
+                "                templateId: 'test-template-1',\n" +
+                "                variables: [\n" +
+                "                  [key: 'name', value: 'integration-test'],\n" +
+                "                  [key: 'image', value: 'ami-test123'],\n" +
+                "                  [key: 'instance_type', value: 'm5.large']\n" +
+                "                ]\n" +
+                "              )\n" +
+                "              echo " + '"' + "Created label UID: ${labelUid}" + '"' + "\n" +
+                "              env.CREATED_LABEL_UID = labelUid\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "        stage('Create Simple Label') {\n" +
+                "          steps {\n" +
+                "            script {\n" +
+                "              def simpleUid = aquariumCreateLabel(\n" +
+                "                templateId: 'simple-template'\n" +
+                "              )\n" +
+                "              echo " + '"' + "Created simple label UID: ${simpleUid}" + '"' + "\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "    stage('Verify Creation') {\n" +
+                "      steps {\n" +
+                "        script {\n" +
+                "          echo " + '"' + "Label creation completed with UID: ${env.CREATED_LABEL_UID}" + '"' + "\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(jenkinsfile, true));
+
+        WorkflowRun build = j.buildAndAssertSuccess(job);
+
+        String log = JenkinsRule.getLog(build);
+        System.out.println("Log: " + log);
+
+        assertTrue("Log must contain 'Running on fish-'", log.contains("Running on fish-"));
+        assertTrue("Created label UID must be echoed", log.contains("Created label UID:"));
+        assertTrue("Created simple label UID must be echoed", log.contains("Created simple label UID:"));
+        assertTrue("Label creation completed must be echoed", log.contains("Label creation completed with UID:"));
+    }
+
+    @Test
+    public void testCreateLabelWithMissingVariable() throws Exception {
+        fishHelper.startFishNode(null);
+
+        assertTrue("Fish must be running", fishHelper.isRunning());
+        fishHelper.createAdvancedTestUser();
+
+        String labelUid = fishHelper.createTestLabel();
+        assertNotNull(labelUid);
+
+        // Create label templates for testing
+        List<AquariumLabelTemplate> templates = createTestLabelTemplates();
+
+        AquariumCloudConfiguration config = fishHelper.getPluginConfig(j);
+        AquariumCloudConfiguration configWithTemplates = new AquariumCloudConfiguration.Builder()
+                .enabled(config.isEnabled())
+                .initAddress(config.getInitAddress())
+                .credentialsId(config.getCredentialsId())
+                .certificateId(config.getCertificateId())
+                .agentConnectionWaitMinutes(config.getAgentConnectionWaitMinutes())
+                .jenkinsUrl(config.getJenkinsUrl())
+                .additionalMetadata(config.getAdditionalMetadata())
+                .labelFilter(config.getLabelFilter())
+                .labelTemplates(templates)
+                .build();
+
+        AquariumCloud cloud = new AquariumCloud("create-label-test-cloud-fail", configWithTemplates);
+        Jenkins jenkins = j.getInstance();
+        jenkins.clouds.add(cloud);
+
+        Thread.sleep(3000);
+        assertTrue("Cloud should connect", cloud.isConnected());
+
+        // Create a Pipeline job that should fail due to missing variable
+        WorkflowJob job = j.createProject(WorkflowJob.class, "create-label-pipeline-fail");
+
+        String jenkinsfile = "" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('Create Label Test - Should Fail') {\n" +
+                "      agent { label 'jenkins-test-label' }\n" +
+                "      stages {\n" +
+                "        stage('Create Label with Missing Variable') {\n" +
+                "          steps {\n" +
+                "            script {\n" +
+                "              try {\n" +
+                "                def labelUid = aquariumCreateLabel(\n" +
+                "                  templateId: 'test-template-1',\n" +
+                "                  variables: [\n" +
+                "                    [key: 'name', value: 'integration-test']\n" +
+                "                    // Missing 'image' and 'instance_type' variables\n" +
+                "                  ]\n" +
+                "                )\n" +
+                "                error('Should have failed due to missing variables')\n" +
+                "              } catch (Exception e) {\n" +
+                "                echo " + '"' + "Expected failure: ${e.message}" + '"' + "\n" +
+                "                if (e.message.contains('Unresolved variable')) {\n" +
+                "                  echo 'Test passed: Missing variable error detected'\n" +
+                "                } else {\n" +
+                "                  throw e\n" +
+                "                }\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(jenkinsfile, true));
+
+        WorkflowRun build = j.buildAndAssertSuccess(job);
+
+        String log = JenkinsRule.getLog(build);
+        System.out.println("Log: " + log);
+
+        assertTrue("Log must contain expected failure message", log.contains("Expected failure:"));
+        assertTrue("Log must contain test passed message", log.contains("Test passed: Missing variable error detected"));
+    }
+
+    @Test
+    public void testCreateLabelWithPredefinedVariables() throws Exception {
+        fishHelper.startFishNode(null);
+
+        assertTrue("Fish must be running", fishHelper.isRunning());
+        fishHelper.createAdvancedTestUser();
+
+        String labelUid = fishHelper.createTestLabel();
+        assertNotNull(labelUid);
+
+        // Create label templates for testing
+        List<AquariumLabelTemplate> templates = createTestLabelTemplates();
+
+        AquariumCloudConfiguration config = fishHelper.getPluginConfig(j);
+        AquariumCloudConfiguration configWithTemplates = new AquariumCloudConfiguration.Builder()
+                .enabled(config.isEnabled())
+                .initAddress(config.getInitAddress())
+                .credentialsId(config.getCredentialsId())
+                .certificateId(config.getCertificateId())
+                .agentConnectionWaitMinutes(config.getAgentConnectionWaitMinutes())
+                .jenkinsUrl(config.getJenkinsUrl())
+                .additionalMetadata(config.getAdditionalMetadata())
+                .labelFilter(config.getLabelFilter())
+                .labelTemplates(templates)
+                .build();
+
+        AquariumCloud cloud = new AquariumCloud("create-label-test-cloud-predefined", configWithTemplates);
+        Jenkins jenkins = j.getInstance();
+        jenkins.clouds.add(cloud);
+
+        Thread.sleep(3000);
+        assertTrue("Cloud should connect", cloud.isConnected());
+
+        // Create a Pipeline job that uses predefined variables
+        WorkflowJob job = j.createProject(WorkflowJob.class, "create-label-pipeline-predefined");
+
+        String jenkinsfile = "" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('Create Label with Predefined Variables') {\n" +
+                "      agent { label 'jenkins-test-label' }\n" +
+                "      stages {\n" +
+                "        stage('Create Label with Timestamp') {\n" +
+                "          steps {\n" +
+                "            script {\n" +
+                "              def labelUid = aquariumCreateLabel(\n" +
+                "                templateId: 'timestamp-template'\n" +
+                "              )\n" +
+                "              echo " + '"' + "Created timestamp label UID: ${labelUid}" + '"' + "\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        job.setDefinition(new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(jenkinsfile, true));
+
+        WorkflowRun build = j.buildAndAssertSuccess(job);
+
+        String log = JenkinsRule.getLog(build);
+        System.out.println("Log: " + log);
+
+        assertTrue("Log must contain 'Running on fish-'", log.contains("Running on fish-"));
+        assertTrue("Created timestamp label UID must be echoed", log.contains("Created timestamp label UID:"));
+    }
+
+    private List<AquariumLabelTemplate> createTestLabelTemplates() {
+        List<AquariumLabelTemplate> templates = new ArrayList<>();
+
+        // Template 1: Basic template with variables
+        String template1Content = "" +
+                "name: test-${name}-${TIMESTAMP}\n" +
+                "version: 0\n" +
+                "visible_for:\n" +
+                "  - jenkins\n" +
+                "  - jenkins-group\n" +
+                "remove_at: '${NOW+1*HOUR}'\n" +
+                "definitions:\n" +
+                "  - driver: aws\n" +
+                "    images:\n" +
+                "      - name: '${image}'\n" +
+                "    options:\n" +
+                "      instance_type: '${instance_type}'\n" +
+                "      security_groups:\n" +
+                "        - test-group\n" +
+                "      userdata_format: env\n" +
+                "    resources:\n" +
+                "      cpu: 2\n" +
+                "      ram: 4\n" +
+                "      network: Subnet:test\n" +
+                "      lifetime: 2h\n" +
+                "metadata:\n" +
+                "  TEST_MODE: 'true'\n" +
+                "  JENKINS_AGENT_WORKSPACE: /tmp/ws";
+
+        AquariumLabelTemplate template1 = new AquariumLabelTemplate(
+                "test-template-1",
+                "Test Template 1",
+                template1Content
+        );
+        template1.setDescription("Template for testing with variables");
+        templates.add(template1);
+
+        // Template 2: Simple template without variables
+        String template2Content = "" +
+                "name: simple-test-label\n" +
+                "version: 0\n" +
+                "visible_for:\n" +
+                "  - jenkins\n" +
+                "definitions:\n" +
+                "  - driver: local\n" +
+                "    resources:\n" +
+                "      cpu: 1\n" +
+                "      ram: 2\n" +
+                "metadata:\n" +
+                "  SIMPLE_MODE: 'true'";
+
+        AquariumLabelTemplate template2 = new AquariumLabelTemplate(
+                "simple-template",
+                "Simple Test Template",
+                template2Content
+        );
+        template2.setDescription("Simple template without variables");
+        templates.add(template2);
+
+        // Template 3: Template with predefined variables
+        String template3Content = "" +
+                "name: timestamp-test-${TIMESTAMP}\n" +
+                "version: 0\n" +
+                "visible_for:\n" +
+                "  - jenkins\n" +
+                "remove_at: '${NOW+2*HOUR}'\n" +
+                "definitions:\n" +
+                "  - driver: test\n" +
+                "    resources:\n" +
+                "      cpu: 1\n" +
+                "      ram: 1\n" +
+                "      lifetime: 1h\n" +
+                "metadata:\n" +
+                "  CREATED_AT: '${TIMESTAMP}'";
+
+        AquariumLabelTemplate template3 = new AquariumLabelTemplate(
+                "timestamp-template",
+                "Timestamp Test Template",
+                template3Content
+        );
+        template3.setDescription("Template using predefined variables");
+        templates.add(template3);
+
+        return templates;
+    }
+}

--- a/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumCreateLabelStepIT.java
+++ b/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumCreateLabelStepIT.java
@@ -295,8 +295,7 @@ public class AquariumCreateLabelStepIT {
                 "name: test-${name}-${TIMESTAMP}\n" +
                 "version: 0\n" +
                 "visible_for:\n" +
-                "  - jenkins\n" +
-                "  - jenkins-group\n" +
+                "  - jenkins-user\n" +
                 "remove_at: '${NOW+1*HOUR}'\n" +
                 "definitions:\n" +
                 "  - driver: aws\n" +
@@ -329,7 +328,8 @@ public class AquariumCreateLabelStepIT {
                 "name: simple-test-label\n" +
                 "version: 0\n" +
                 "visible_for:\n" +
-                "  - jenkins\n" +
+                "  - jenkins-user\n" +
+                "remove_at: '${NOW+2*MINUTE}'\n" +
                 "definitions:\n" +
                 "  - driver: local\n" +
                 "    resources:\n" +
@@ -351,7 +351,7 @@ public class AquariumCreateLabelStepIT {
                 "name: timestamp-test-${TIMESTAMP}\n" +
                 "version: 0\n" +
                 "visible_for:\n" +
-                "  - jenkins\n" +
+                "  - jenkins-user\n" +
                 "remove_at: '${NOW+2*HOUR}'\n" +
                 "definitions:\n" +
                 "  - driver: test\n" +

--- a/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumFishTestHelper.java
+++ b/src/test/java/com/adobe/ci/aquarium/net/integration/AquariumFishTestHelper.java
@@ -284,6 +284,10 @@ public class AquariumFishTestHelper extends ExternalResource {
                 RoleOuterClass.Permission.newBuilder()
                     .setResource("LabelService").setAction("Get").build()
             )
+            .addPermissions(
+                RoleOuterClass.Permission.newBuilder()
+                    .setResource("LabelService").setAction("Create").build()
+            )
             // User - StreamingService
             .addPermissions(
                 RoleOuterClass.Permission.newBuilder()


### PR DESCRIPTION
Allows to create label templates and fill them with pipeline data to reach the goal of reproducing the failed environments after their termination. Primarily aimed to temp environments, but could be used anywhere to allow anyone to get what's up with any environment.

## Related Issue

Fixes: #36 

## Motivation and Context

Straight to the North Star

## How Has This Been Tested?

Manually & automatically

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

